### PR TITLE
Remove array-macro dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "segmentmap"
-version = "0.1.4"
+version = "0.1.5"
 edition = "2021"
 description = "A collection that maintains insertion order"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["collection"]
 
 [dependencies]
 bitmaps = "3.2.0"
-array-macro = "2.1.5"
 
 [dev-dependencies]
 criterion = "0.4.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,8 @@
 #![warn(clippy::pedantic)]
+use std::array;
 use std::collections::HashMap;
 
-use array_macro::array;
 use bitmaps::Bitmap;
-
 pub const SEGMENTSIZE: usize = 128;
 
 #[derive(Clone, Default, Debug)]
@@ -223,7 +222,7 @@ struct Segment<T> {
 impl<T> Segment<T> {
     fn new() -> Self {
         Self {
-            data: array!(_ => None; SEGMENTSIZE),
+            data: array::from_fn(|_| None),
             bitmap: Bitmap::<SEGMENTSIZE>::new(),
             next_index: None,
             previous_index: None,


### PR DESCRIPTION
It's no longer necessary with `std::array::from_fn` in the standard library.